### PR TITLE
Ban Josh/N0_Hat

### DIFF
--- a/people/banned.md
+++ b/people/banned.md
@@ -12,3 +12,5 @@ The following people are unwelcome at Noisebridge. They are prohibited from ente
 * Chris (aka Raging Bull)
 * Harvey
 * Joseph Adam Moore
+* Josh “N0_Hat”
+


### PR DESCRIPTION
I've heard plenty of reports that [Josh/N0_Hat](https://noisebridge.net/wiki/User:N0_Hat) has been using Noisebridge as one of the main places they sleep. Sever folks have found Josh asleep when they show up in the morning. That's not okay.
